### PR TITLE
Enable Dependabot for gradle dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
     labels:
       - "dependencies"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"


### PR DESCRIPTION
## Summary
Adds Dependabot configuration to enable automated dependency updates for gradle packages.

## Configuration
- **Ecosystem:** gradle
- **Schedule:** Weekly
- **PR Limit:** 10 open PRs max

## What this does
- Dependabot will automatically create PRs when new versions of dependencies are available
- Security updates will be prioritized
- PRs will be labeled with `dependencies` for easy filtering

---
🤖 Generated by Claude Code Security Review
